### PR TITLE
Override BucketURL

### DIFF
--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -85,7 +85,7 @@ Object.defineProperty(ToolkitInfo.prototype, 'bucketUrl', {
   get() {
     const bucket = this.requireOutput(bootstrap.BUCKET_NAME_OUTPUT);
     const domain = this.requireOutput(bootstrap.BUCKET_DOMAIN_NAME_OUTPUT);
-    return `https://${domain.replace(bucket, '')}/${bucket}`
+    return `https://${domain.replace(`${bucket}.`, '')}/${bucket}`
   }
 });
 

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -3,6 +3,8 @@
 const provider = require('aws-cdk/lib/api/aws-auth/sdk-provider');
 const { CdkToolkit } = require('aws-cdk/lib/cdk-toolkit');
 const { SDK } = require('aws-cdk/lib/api/aws-auth/sdk');
+const bootstrap = require("aws-cdk/lib/api/bootstrap");
+const { ToolkitInfo }  = require('aws-cdk/lib/api/toolkit-info');
 
 const DEFAULT_EDGE_PORT = 4566;
 const DEFAULT_HOSTNAME = 'localhost';
@@ -76,6 +78,14 @@ getMethods(CdkToolkit.prototype).forEach(meth => {
   CdkToolkit.prototype[meth] = function() {
     setOptions(this.props.sdkProvider.sdkOptions);
     return original.bind(this).apply(this, arguments);
+  }
+});
+
+Object.defineProperty(ToolkitInfo.prototype, 'bucketUrl', {
+  get() {
+    const bucket = this.requireOutput(bootstrap.BUCKET_NAME_OUTPUT);
+    const domain = this.requireOutput(bootstrap.BUCKET_DOMAIN_NAME_OUTPUT);
+    return `https://${domain.replace(bucket, '')}/${bucket}`
   }
 });
 

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -3,8 +3,8 @@
 const provider = require('aws-cdk/lib/api/aws-auth/sdk-provider');
 const { CdkToolkit } = require('aws-cdk/lib/cdk-toolkit');
 const { SDK } = require('aws-cdk/lib/api/aws-auth/sdk');
-const bootstrap = require("aws-cdk/lib/api/bootstrap");
-const { ToolkitInfo }  = require('aws-cdk/lib/api/toolkit-info');
+const { BUCKET_NAME_OUTPUT, BUCKET_DOMAIN_NAME_OUTPUT } = require("aws-cdk/lib/api/bootstrap/bootstrap-props");
+const { ToolkitInfo }  = require('aws-cdk/lib/api');
 
 const DEFAULT_EDGE_PORT = 4566;
 const DEFAULT_HOSTNAME = 'localhost';
@@ -83,8 +83,8 @@ getMethods(CdkToolkit.prototype).forEach(meth => {
 
 Object.defineProperty(ToolkitInfo.prototype, 'bucketUrl', {
   get() {
-    const bucket = this.requireOutput(bootstrap.BUCKET_NAME_OUTPUT);
-    const domain = this.requireOutput(bootstrap.BUCKET_DOMAIN_NAME_OUTPUT);
+    const bucket = this.requireOutput(BUCKET_NAME_OUTPUT);
+    const domain = this.requireOutput(BUCKET_DOMAIN_NAME_OUTPUT);
     return `https://${domain.replace(`${bucket}.`, '')}/${bucket}`
   }
 });


### PR DESCRIPTION
CDK creates and uploads `template.yml` file on S3 when template size exceeds from 50KB [CDK code reference](https://github.com/aws/aws-cdk/blob/4887ba6004b20c86c0025d16e235b8333d6efa6b/packages/aws-cdk/lib/api/deploy-stack.ts#L312) and adds `TemplateURL` prop in the changeset. In the latest version of CDK, this `TemplateURL` is generated as `Virtual Hosted-Style` which doesn't work with LocalStack. This PR overrides that getter to generate `Path-Style` URLs to fix that issue. 
