### PR TITLE
chore(dependencies): add diff dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "diff": "^5.0.0"
   },
   "repository": {
     "url": "https://github.com/localstack/aws-cdk-local.git",


### PR DESCRIPTION
**Background**
The following commit uses npm package diff, to check circular references in json, see below:

https://github.com/localstack/aws-cdk-local/commit/3dcea126532b72d12f3fa3fd751fa4f3192d163b#diff-7900c45c84ebee1e7a42268a42b38ebd333a2c51d849afcecbd5ac76eaa6a49aR176

**Problem**
After installing latest version, it fails with following error message:

```Cannot find module 'diff' ```

**Solution**
As evident from this pull request, adding dependency in package.json fixes the problem