### PR TITLE
Attempt to deserialize anything that leaves getTemplateBody due to [1]

### DIFF
--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -83,8 +83,7 @@ const fetchURLAsync = (url) => {
         responseBody += chunk;
       });
       res.on('end', () => {
-        const result = deserializeStructure(responseBody || '{}');
-        resolve(result);
+        resolve(responseBody || '{}');
       });
     });
     req.on('error', (err) => {
@@ -225,7 +224,7 @@ deployStackMod.deployStack = async function deployStack(options) {
   cfn.createChangeSetOrig = cfn.createChangeSetOrig || cfn.createChangeSet;
   const createChangeSetAsync = async function(params) {
     if (LAMBDA_MOUNT_CODE) {
-      const template = await getTemplateBody(params);
+      const template = deserializeStructure(await getTemplateBody(params));
       symlinkLambdaAssets(template, params.Parameters);
     }
     return cfn.createChangeSetOrig(params).promise();


### PR DESCRIPTION
The template body may end up being YAML, but the parsing logic expects a parsed JSON structure.

\[1\]: https://github.com/aws/aws-cdk/blob/81cbfec5ddf065aac442d925484a358ee8cd26a1/packages/aws-cdk/lib/api/deploy-stack.ts#L335