### PR TITLE
Remove node12 from matrix (incompatible with new cdk version)

### DIFF
--- a/.github/workflows/integrations.node.yml
+++ b/.github/workflows/integrations.node.yml
@@ -27,7 +27,6 @@ jobs:
           - { language: typescript, node-version: '16.x', region: eu-west-2}
           - { language: typescript, node-version: '16.x', region: us-east-1}
           - { language: typescript, node-version: '14.x', region: us-east-1}
-          - { language: typescript, node-version: '12.x', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/.github/workflows/integrations.python.yml
+++ b/.github/workflows/integrations.python.yml
@@ -26,7 +26,6 @@ jobs:
           - { language: python, node-version: '16.x', python-version: '3.10', region: us-east-1}
           - { language: python, node-version: '16.x', python-version: '3.9', region: us-east-1}
           - { language: python, node-version: '16.x', python-version: '3.8', region: us-east-1}
-          - { language: python, node-version: '16.x', python-version: '3.7', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}


### PR DESCRIPTION
Seems the new CDK version isn't compatible with Node 12 anymore syntaxwise (using ES6 syntax)