### PR TITLE
Fix nodejs 17 localhost connection error with ipv4 fallback

### DIFF
--- a/.github/workflows/integrations.go.yml
+++ b/.github/workflows/integrations.go.yml
@@ -23,9 +23,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - { language: go, node-version: '16.x', go-version: '1.16.15', region: us-east-1}
+        # The AWS CDK only supports third-party languages "until its EOL (End Of Life) shared by the vendor or community"
+        # https://github.com/aws/aws-cdk
+        # Golang EOL overview: https://endoflife.date/go
           - { language: go, node-version: '16.x', go-version: '1.17.8', region: us-east-1}
           - { language: go, node-version: '16.x', go-version: '1.18', region: us-east-1}
+          - { language: go, node-version: '18.x', go-version: '1.20', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 2.17.0: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * 2.16.0: Add check to prevent IPv6 connection issue with `localhost` on MacOS
 * 2.15.0: Fix issue with undefined BUCKET_NAME_OUTPUT variable; add CI build and eslint config
 * 2.14.0: Add switches in patches to accommodate new esbuild packaging mechanism in CDK v2.14.0+

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -33,24 +33,52 @@ const getLocalHost = async () => {
   }
 
   var hostname = process.env.LOCALSTACK_HOSTNAME || DEFAULT_HOSTNAME;
-  // attempt to connect to the given host/port
-  const socket = new net.Socket();
-  try {
-    await socket.connect({ host: hostname, port });
-  } catch (e) {
-    if (hostname === "localhost") {
-      // fall back to using local IPv4 address - to fix IPv6 issue on MacOS
-      // see, https://github.com/localstack/serverless-localstack/issues/125
-      // and https://github.com/localstack/aws-cdk-local/issues/78
+  // Fall back to using local IPv4 address if connection to localhost fails.
+  // This workaround transparently handles systems (e.g., macOS) where
+  // localhost resolves to IPv6 when using Nodejs >=v17. See discussion:
+  // https://github.com/localstack/aws-cdk-local/issues/76#issuecomment-1412590519
+  // Issue: https://github.com/localstack/aws-cdk-local/issues/78
+  if (hostname === "localhost") {
+    try {
+      const options = { host: hostname, port: port };
+      await checkTCPConnection(options);
+    } catch (e) {
       hostname = "127.0.0.1";
     }
-  } finally {
-    socket.destroy();
   }
 
   resolvedHostname = hostname;
   return `${hostname}:${port}`;
 };
+
+/**
+ * Checks whether a TCP connection to the given "options" can be established.
+ * @param {object} options connection options of net.socket.connect()
+ *                 https://nodejs.org/api/net.html#socketconnectoptions-connectlistener
+ *                 Example: { host: "localhost", port: 4566 }
+ * @returns {Promise} A fulfilled empty promise on successful connection and
+ *                    a rejected promise on any connection error.
+ */
+const checkTCPConnection = async (options) => {
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+    const client = socket.connect(options, () => {
+      client.end();
+      resolve();
+    });
+
+    client.setTimeout(500);  // milliseconds
+    client.on("timeout", err => {
+      client.destroy();
+      reject(err);
+    });
+
+    client.on("error", err => {
+      client.destroy();
+      reject(err);
+    });
+  });
+}
 
 const useLocal = () => {
   // TODO make configurable..?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.15.0",
+  "version": "2.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.15.0",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "bin": {
     "cdklocal": "bin/cdklocal"
   },


### PR DESCRIPTION
This PR transparently circumvents connection issues with Nodejs >=v17 on macOS because localhost resolves to IPv6. It fixes a Javascript error in the `getLocalHost()` workaround from the previous PR https://github.com/localstack/serverless-localstack/pull/205

Full explanation in https://github.com/localstack/aws-cdk-local/issues/76#issuecomment-1412590519

Addresses:

* https://github.com/localstack/aws-cdk-local/issues/76
* https://github.com/localstack/aws-cdk-local/issues/78
* https://github.com/localstack/aws-cdk-local/issues/39

serverless-localstack companion PR: https://github.com/localstack/serverless-localstack/pull/210

## Problem

net.Socket.connect used [here](https://github.com/localstack/aws-cdk-local/pull/79/files#diff-7900c45c84ebee1e7a42268a42b38ebd333a2c51d849afcecbd5ac76eaa6a49aR39) does not support promises. Hence, the try-catch block has no effect.

## Solution

* Add a helper `checkTCPConnection()` that adds support for promises by mapping socket events such as `on("error")`.
* Only run the fallback check if hostname is `localhost`

## Testing

Tested on macOS 13.1 with Node v19.

Standalone Node example to reproduce IPv6 issue:

```js
const socket = new net.Socket();

var hostname = 'localhost'
hostname = '127.0.0.1'
const port = 4566

socket.connect({ host: hostname, port }, () => {
  console.log(`connected to ${hostname}:${port}`)
})
```
