### PR TITLE
Add support for USE_SSL and AWS_ENDPOINT_URL configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+cdk.context.json

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The following environment variables can be configured:
 
 * `EDGE_PORT`: Port under which LocalStack edge service is accessible (default: `4566`)
 * `LOCALSTACK_HOSTNAME`: Target host under which LocalStack edge service is accessible (default: `localhost`)
+* `USE_SSL`: Whether to use SSL to connect to the LocalStack endpoint, i.e., connect via HTTPS
+* `AWS_ENDPOINT_URL`: Configure a full endpoint URL to connect to (combination of `USE_SSL`/`LOCALSTACK_HOSTNAME`/`EDGE_PORT` above)
 * `LAMBDA_MOUNT_CODE`: Whether to use local Lambda code mounting (via setting `__local__` S3 bucket name). Note: may require CDK version <2.14.0 to be fully functional.
 
 ## Deploying a Sample App
@@ -67,6 +69,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 2.18.0: Add support for USE_SSL and AWS_ENDPOINT_URL configurations
 * 2.17.0: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * 2.16.0: Add check to prevent IPv6 connection issue with `localhost` on MacOS
 * 2.15.0: Fix issue with undefined BUCKET_NAME_OUTPUT variable; add CI build and eslint config

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ $ cdklocal --version
 
 The following environment variables can be configured:
 
-* `EDGE_PORT`: Port under which LocalStack edge service is accessible (default: `4566`)
-* `LOCALSTACK_HOSTNAME`: Target host under which LocalStack edge service is accessible (default: `localhost`)
-* `USE_SSL`: Whether to use SSL to connect to the LocalStack endpoint, i.e., connect via HTTPS
-* `AWS_ENDPOINT_URL`: Configure a full endpoint URL to connect to (combination of `USE_SSL`/`LOCALSTACK_HOSTNAME`/`EDGE_PORT` above)
+* `AWS_ENDPOINT_URL`: The endpoint URL to connect to (combination of `USE_SSL`/`LOCALSTACK_HOSTNAME`/`EDGE_PORT` below)
+* `EDGE_PORT` (deprecated): Port under which LocalStack edge service is accessible (default: `4566`)
+* `LOCALSTACK_HOSTNAME` (deprecated): Target host under which LocalStack edge service is accessible (default: `localhost`)
+* `USE_SSL` (deprecated): Whether to use SSL to connect to the LocalStack endpoint, i.e., connect via HTTPS.
 * `LAMBDA_MOUNT_CODE`: Whether to use local Lambda code mounting (via setting `__local__` S3 bucket name). Note: may require CDK version <2.14.0 to be fully functional.
+* `BUCKET_MARKER_LOCAL`: Magic S3 bucket name for Lambda mount and [hot reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading) (default: `__local__`, will default to `hot-reload` in a future release)
 
 ## Deploying a Sample App
 
@@ -69,7 +70,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
-* 2.18.0: Add support for USE_SSL and AWS_ENDPOINT_URL configurations
+* 2.18.0: Add support for AWS_ENDPOINT_URL, USE_SSL, and BUCKET_MARKER_LOCAL configurations
 * 2.17.0: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * 2.16.0: Add check to prevent IPv6 connection issue with `localhost` on MacOS
 * 2.15.0: Fix issue with undefined BUCKET_NAME_OUTPUT variable; add CI build and eslint config

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -259,7 +259,8 @@ const patchLambdaMounting = (CdkToolkit) => {
       const paramKey = item.ParameterKey || key;
       // TODO: create a more resilient lookup mechanism (not based on "S3Bucket" param key) below!
       if (item.ParameterKey && item.ParameterKey.includes("S3Bucket")) {
-        item.ParameterValue = "__local__";
+        // TODO: change the default BUCKET_MARKER_LOCAL to 'hot-reload'
+        item.ParameterValue = process.env.BUCKET_MARKER_LOCAL || '__local__'; // for now, the default is still __local__
       }
       if (!paramKey.includes("S3VersionKey")) {
         return;

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -9,27 +9,29 @@ const https = require("https");
 const crypto = require("crypto");
 const net = require('net');
 
-// config constants
+// constants and custom config values
+
+const isEnvTrue = (envName) => ["1", "true"].includes(process.env[envName]);
 
 const DEFAULT_EDGE_PORT = 4566;
+const EDGE_PORT = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
 const DEFAULT_HOSTNAME = "localhost";
-const LAMBDA_MOUNT_CODE = ["1", "true"].includes(process.env.LAMBDA_MOUNT_CODE);
+const LAMBDA_MOUNT_CODE = isEnvTrue("LAMBDA_MOUNT_CODE");
+const PROTOCOL = isEnvTrue("USE_SSL") ? "https" : "http";
 
 
 //----------------
 // UTIL FUNCTIONS
 //----------------
 
-const getLocalEndpoint = async () => `http://${await getLocalHost()}`;
-
-const port = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
+const getLocalEndpoint = async () => process.env.AWS_ENDPOINT_URL || `${PROTOCOL}://${await getLocalHost()}`;
 
 var resolvedHostname = undefined;
 
 const getLocalHost = async () => {
   if (resolvedHostname) {
     // early exit to not resolve again
-    return `${resolvedHostname}:${port}`;
+    return `${resolvedHostname}:${EDGE_PORT}`;
   }
 
   var hostname = process.env.LOCALSTACK_HOSTNAME || DEFAULT_HOSTNAME;
@@ -40,7 +42,7 @@ const getLocalHost = async () => {
   // Issue: https://github.com/localstack/aws-cdk-local/issues/78
   if (hostname === "localhost") {
     try {
-      const options = { host: hostname, port: port };
+      const options = { host: hostname, port: EDGE_PORT };
       await checkTCPConnection(options);
     } catch (e) {
       hostname = "127.0.0.1";
@@ -48,7 +50,7 @@ const getLocalHost = async () => {
   }
 
   resolvedHostname = hostname;
-  return `${hostname}:${port}`;
+  return `${hostname}:${EDGE_PORT}`;
 };
 
 /**
@@ -204,7 +206,7 @@ const patchToolkitInfo = (ToolkitInfo) => {
       async get () {
         const bucket = this.requireOutput(BUCKET_NAME_OUTPUT);
         const domain = this.requireOutput(BUCKET_DOMAIN_NAME_OUTPUT) || await getLocalHost();
-        return `https://${domain.replace(`${bucket}.`, "")}:${port}/${bucket}`;
+        return `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;
       }
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "bin": {
     "cdklocal": "bin/cdklocal"
   },


### PR DESCRIPTION
Add support for `USE_SSL` and `AWS_ENDPOINT_URL` configurations. This has recently surfaced when attempting a CDK deployment against a LocalStack instance deployed behind an HTTPS endpoint.

Over time, I'm envisioning that we can simplify and streamline the configurations (e.g., only use `AWS_ENDPOINT_URL`). Adding these config options (incl. `USE_SSL`) for now, for compatibility with the existing configs used across different tools (`awslocal`, `tflocal`, ...).

/cc @simonrw @dominikschubert @joe4dev 