### PR TITLE
Throw somewhat better exception if aws-cdk is missing

### DIFF
--- a/.github/workflows/integrations.go.yml
+++ b/.github/workflows/integrations.go.yml
@@ -26,9 +26,9 @@ jobs:
         # The AWS CDK only supports third-party languages "until its EOL (End Of Life) shared by the vendor or community"
         # https://github.com/aws/aws-cdk
         # Golang EOL overview: https://endoflife.date/go
-          - { language: go, node-version: '16.x', go-version: '1.17.8', region: us-east-1}
-          - { language: go, node-version: '16.x', go-version: '1.18', region: us-east-1}
-          - { language: go, node-version: '18.x', go-version: '1.20', region: us-east-1}
+          - { language: go, node-version: '18.x', go-version: '1.18', region: us-east-1}
+          - { language: go, node-version: '20.x', go-version: '1.20', region: us-east-1}
+          - { language: go, node-version: '22.x', go-version: '1.22', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/.github/workflows/integrations.node.yml
+++ b/.github/workflows/integrations.node.yml
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { language: javascript, node-version: '16.x', region: us-east-1}
-          - { language: typescript, node-version: '16.x', region: eu-west-2}
-          - { language: typescript, node-version: '16.x', region: us-east-1}
-          - { language: typescript, node-version: '14.x', region: us-east-1}
+          - { language: javascript, node-version: '18.x', region: us-east-1}
+          - { language: typescript, node-version: '20.x', region: eu-west-2}
+          - { language: typescript, node-version: '21.x', region: us-east-1}
+          - { language: typescript, node-version: '22.x', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/.github/workflows/integrations.python.yml
+++ b/.github/workflows/integrations.python.yml
@@ -23,9 +23,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { language: python, node-version: '16.x', python-version: '3.10', region: us-east-1}
-          - { language: python, node-version: '16.x', python-version: '3.9', region: us-east-1}
-          - { language: python, node-version: '16.x', python-version: '3.8', region: us-east-1}
+          - { language: python, node-version: '18.x', python-version: '3.9', region: us-east-1}
+          - { language: python, node-version: '20.x', python-version: '3.10', region: us-east-1}
+          - { language: python, node-version: '21.x', python-version: '3.11', region: us-east-1}
+          - { language: python, node-version: '22.x', python-version: '3.12', region: us-east-1}
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a thin wrapper script `cdklocal` for using the [AWS CDK](h
 ## Quick Installation
 
 The `cdklocal` command line is published as an [npm library](https://www.npmjs.com/package/aws-cdk-local):
-```
+```bash
 $ npm install -g aws-cdk-local aws-cdk
 ...
 $ cdklocal --version
@@ -20,6 +20,13 @@ $ cdklocal --version
 (to decouple the two libraries, and allow using arbitrary versions of `aws-cdk` under the covers).
 
 (Note: Depending on your local setup, you may or may not have to use the global `npm` installation flag `-g` above.)
+
+### Mac OS specific `MODULE_NOT_FOUND` issue
+On Mac OS, brew could be used to install AWS CDK, which will result in a `MODULE_NOT_FOUND` error from `cdklocal`.  
+To resolve this, set the `NODE_PATH` variable pointing to your AWS CDK's `node_module` folder to expand the lookup path for modules.
+```bash
+$ export NODE_PATH=$NODE_PATH:/opt/homebrew/Cellar/aws-cdk/<CDK_VERSION>/libexec/lib/node_modules
+```
 
 ## Configurations
 
@@ -35,19 +42,19 @@ The following environment variables can be configured:
 ## Deploying a Sample App
 
 The CDK command line ships with a sample app generator to run a quick test for getting started:
-```
+```bash
 $ mkdir /tmp/test; cd /tmp/test
 $ cdklocal init sample-app --language=javascript
 ...
 ```
 
 Make sure that LocalStack is installed and started up with the required services:
-```
+```bash
 $ SERVICES=serverless,sqs,sns localstack start
 ```
 
 Then deploy the sample app against the local APIs via the `cdklocal` command line:
-```
+```bash
 $ cdklocal deploy
 ...
 Do you wish to deploy these changes (y/n)? y
@@ -57,7 +64,7 @@ arn:aws:cloudformation:us-east-1:000000000000:stack/TestStack/e3debc0a-311e-4968
 ```
 
 Once the deployment is done, you can inspect the created resources via the [`awslocal`](https://github.com/localstack/awscli-local) command line:
-```
+```bash
 $ awslocal sns list-topics
 {
     "Topics": [
@@ -70,6 +77,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 2.18.1: Throw better exception if `aws-cdk` not found
 * 2.18.0: Add support for AWS_ENDPOINT_URL, USE_SSL, and BUCKET_MARKER_LOCAL configurations
 * 2.17.0: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * 2.16.0: Add check to prevent IPv6 connection issue with `localhost` on MacOS

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ cdklocal --version
 (Note: Depending on your local setup, you may or may not have to use the global `npm` installation flag `-g` above.)
 
 ### Mac OS specific `MODULE_NOT_FOUND` issue
-On Mac OS, brew could be used to install AWS CDK, which will result in a `MODULE_NOT_FOUND` error from `cdklocal`.  
+On Mac OS, brew can be used to install AWS CDK, which might result in a `MODULE_NOT_FOUND` error from `cdklocal`.  
 To resolve this, set the `NODE_PATH` variable pointing to your AWS CDK's `node_module` folder to expand the lookup path for modules.
 ```bash
 $ export NODE_PATH=$NODE_PATH:/opt/homebrew/Cellar/aws-cdk/<CDK_VERSION>/libexec/lib/node_modules

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -369,8 +369,8 @@ const patchPre_2_14 = () => {
   } catch(e) {
     if (e.code == "MODULE_NOT_FOUND") {
       console.log(e);
-      console.log("`aws-cdk` module NOT found! Have you tried to add it to your `NODE_PATH`?");
-      process.exit(1);
+      console.error("`aws-cdk` module NOT found! Have you tried adding it to your `NODE_PATH`?");
+      throw e;
     }
   }
 

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -363,16 +363,36 @@ const applyPatches = (provider, CdkToolkit, SDK, ToolkitInfo, patchAssets = true
 };
 
 const patchPre_2_14 = () => {
-  const provider = require("aws-cdk/lib/api/aws-auth");
+  var provider = null;
+  try {
+    provider = require("aws-cdk/lib/api/aws-auth");
+  } catch(e) {
+    if (e.code == "MODULE_NOT_FOUND") {
+      console.log(e);
+      console.log("`aws-cdk` module NOT found! Have you tried to add it to your `NODE_PATH`?");
+      process.exit(1);
+    }
+  }
+
   const {CdkToolkit} = require("aws-cdk/lib/cdk-toolkit");
   const {SDK} = require("aws-cdk/lib/api/aws-auth/sdk");
   const {ToolkitInfo} = require("aws-cdk/lib/api");
+
 
   applyPatches(provider, CdkToolkit, SDK, ToolkitInfo);
 };
 
 const patchPost_2_14 = () => {
-  const lib = require("aws-cdk/lib");
+  var lib = null;
+  try {
+    lib = require("aws-cdk/lib");
+  } catch(e) {
+    if (e.code == "MODULE_NOT_FOUND") {
+      console.log(e);
+      console.log("`aws-cdk` module NOT found! Have you tried to add it to your `NODE_PATH`?");
+      process.exit(1);
+    }
+  }
 
   applyPatches(lib, lib, lib.SDK, lib.ToolkitInfo, false);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "bin": {
     "cdklocal": "bin/cdklocal"
   },


### PR DESCRIPTION
# Motivation
In case of `aws-cdk` is installed by a different package manager (ie brew on Mac OS) as a separate CLI tool `cdklocal` complains that the `aws-cdk` module is missing. To resolve this situation I found that the easiest solution is to add it by the `NODE_PATH` variable that expands the lookup path for modules. ([docs](https://nodejs.org/api/modules.html#loading-from-the-global-folders))
>If the NODE_PATH environment variable is set to a colon-delimited list of absolute paths, then Node.js will search those paths for modules if they are not found elsewhere.

Reported issue: #90

# Changes
- update README
- add small message to exception