### PR TITLE
Add scheduled daily CI runs for regression tests at 5AM

### DIFF
--- a/.github/workflows/integrations.go.yml
+++ b/.github/workflows/integrations.go.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 5 * * *'  # once daily at 5AM
   workflow_dispatch:
     inputs:
       upstream-version:

--- a/.github/workflows/integrations.node.yml
+++ b/.github/workflows/integrations.node.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 5 * * *'  # once daily at 5AM
   workflow_dispatch:
     inputs:
       upstream-version:

--- a/.github/workflows/integrations.python.yml
+++ b/.github/workflows/integrations.python.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 5 * * *'  # once daily at 5AM
   workflow_dispatch:
     inputs:
       upstream-version:


### PR DESCRIPTION
Simple scheduled daily run for our regression tests.

Currently set to 5AM, but that's quite arbitrary and I'm happy for other suggestions :smile: 