### PR TITLE
add workflow to test against multiple aws-cdk versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-cdk-version-matrix
     strategy:
-      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix || "{}")}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
         working-directory: repo
         run: |
           npm install
-          echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Install specific aws-cdk version
         working-directory: repo
@@ -63,6 +62,7 @@ jobs:
           else
             npm install aws-cdk
           fi
+          echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Verify specific aws-cdk version is used by cdklocal
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Obtain aws-cdk versions
         id: set-matrix
         run: |
-          #VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
-          VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq 'sort_by( [ split(".") | .[] | tonumber ] ) | .[-10:]' -c)
+          VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
         id: set-matrix
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
-          echo $VERSIONS_ARRAY
-          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
+          echo "MATRIX={\"cdk-version\":$VERSIONS_ARRAY)}" >> $GITHUB_ENV
+          echo $MATRIX
         shell: bash
  
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
   AWS_SECRET_ACCESS_KEY: test
 
 jobs:
-  integration-python-test:
+  dynamic-cdk-version-testing:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   generate-cdk-version-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.env.MATRIX }}
     steps:
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v2
@@ -35,9 +35,8 @@ jobs:
       - name: Obtain aws-cdk versions
         id: set-matrix
         run: |
-          VERSIONS_ARRAY=$(npm show aws-cdk time --json --silent| jq 'del(.created, .modified) | keys' -c)
-          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}"
-          echo "::set-output name=matrix::$MATRIX"
+          VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
+          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
  
  
   version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,19 +37,22 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
       - name: Obtain all aws-cdk latest versions
-        id: set-matrix
+        id: heavy-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == true }}
         run: |
           VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
-          MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
-          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+          export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
       
       - name: Obtain default list of aws-cdk versions
-        id: set-matrix
+        id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
           VERSIONS_ARRAY=["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]
-          MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+          export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+      
+      - name: Generate matrix
+        id: simple-matrix
+        run: |
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           source .venv/bin/activate
-          cdklocal acknowledge 19836
+          cdk acknowledge 19836
           cdklocal bootstrap
 
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
-          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
+          #echo "MATRIX=$MATRIX" >> $GITHUB_ENV
+          echo "MATRIX=$MATRIX" | tee -a $GITHUB_ENV
           echo $MATRIX
  
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ on:
         description: Upstream aws-cdk version to use in tests
         required: false
 env:
-  AWS_ACCESS_KEY_ID: LSIA2KBGMF64YRBX5E0I
-  AWS_SECRET_ACCESS_KEY: ZgF037sgehvieyj4mejFnipU2HvvwnYQlBsguzLK
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: test
 
 jobs:
   dynamic-cdk-version-testing:
@@ -27,7 +27,8 @@ jobs:
         node-version: ['22.x']
         python-version: ['3.12']
         region: ['us-east-1']
-        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0", ""]') }}
+#        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0", ""]') }}
+        cdk-version: ${{ fromJson(inputs.cdk-version || '[""]') }}
       fail-fast: false
 
     env:
@@ -68,8 +69,13 @@ jobs:
             echo "Latest version installed, skipping version verification."
           fi
 
-      - name: Install AWS CLI
-        run: pip install awscli
+#      - name: Install AWS CLI
+#        run: |
+#          pip install awscli
+#          aws configure set aws_access_key_id "AKIAI44QH8DHBEXAMPLE" --profile default
+#          aws configure set aws_secret_access_key "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY" --profile default
+#          aws configure set region "us-east-1" --profile default
+#          aws configure set output "json" --profile default
 
       - name: Install localstack CLI
         run: pip install localstack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,7 @@ jobs:
 
       - name: Verify specific aws-cdk version is used by cdklocal
         run: |
-          if [ -n "${{ matrix.cdk-version }}" ]; then
-            [[ $(cdklocal --version) =~ ^${{ matrix.cdk-version }}.* ]] || exit 1
-          else
-            echo "Latest version installed, skipping version verification."
-          fi
+          cdklocal --version
 
       - name: Install localstack CLI
         run: pip install localstack
@@ -110,4 +106,4 @@ jobs:
 
       - name: Verify successful deployment
         run: |
-          [ $(aws cloudformation describe-stacks --stack-name AppTest --endpoint-url http://localhost:4566 | jq '[ .Stacks[] | select(.StackStatus == "CREATE_COMPLETE") ] | length') -eq 1 ] || exit 1
+          [ $(aws cloudformation describe-stacks --stack-name $STACK_NAME --endpoint-url http://localhost:4566 | jq '[ .Stacks[] | select(.StackStatus == "CREATE_COMPLETE") ] | length') -eq 1 ] || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,9 @@ jobs:
         id: set-matrix
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
+          echo $VERSIONS_ARRAY
           echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
+        shell: bash
  
  
   version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,10 @@ jobs:
         working-directory: repo
         run: |
           npm install
-          npm install aws-cdk
           if [ -n "${{ matrix.cdk-version }}" ]; then
             npm install aws-cdk@${{ matrix.cdk-version }}
+          else
+            npm install aws-cdk
           fi
           echo "$(pwd)/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,6 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           source .venv/bin/activate
-          cdklocal acknowledge 19836
           cdklocal bootstrap
 
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
         id: set-matrix
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
-          echo "MATRIX={\"cdk-version\":$VERSIONS_ARRAY)}" >> $GITHUB_ENV
+          MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
           echo $MATRIX
-        shell: bash
  
  
   version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ on:
 env:
   AWS_ACCESS_KEY_ID: test
   AWS_SECRET_ACCESS_KEY: test
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
 
 jobs:
   dynamic-cdk-version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY='["1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
+          export VERSIONS_ARRAY='["2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
           echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
 
       - name: Generate matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json --silent| jq 'del(.created, .modified) | keys' -c)
           echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
+          echo $MATRIX
  
   version-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
+          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", "latest"]'
       
       - name: Generate matrix
         id: set-matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,133 @@
+name: Regression Tests (Python)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * *'  # once daily at 5AM
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: Upstream aws-cdk version to use in tests
+        required: false
+env:
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: test
+
+jobs:
+  integration-python-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['22.x']
+        python-version: ['3.12']
+        region: ['us-east-1']
+        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0"]') }}
+      fail-fast: true
+
+    env:
+      AWS_REGION: ${{ matrix.region }}
+      AWS_DEFAULT_REGION: ${{ matrix.region }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: repo
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: '${{ matrix.python-version }}'
+
+      - name: Install dependencies for aws-cdk-local
+        working-directory: repo
+        run: |
+          npm install
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+
+      - name: Install specific aws-cdk version
+        working-directory: repo
+        run:  |
+          if [ -n "${{ matrix.cdk-version }}" ]; then
+            npm install aws-cdk@${{ matrix.cdk-version }}
+          else
+            npm install aws-cdk
+          fi
+
+      - name: Verify specific aws-cdk version is used by cdklocal
+        run: |
+          if [ -n "${{ matrix.cdk-version }}" ]; then
+            [[ $(cdklocal --version) =~ ^${{ matrix.cdk-version }}.* ]] || exit 1
+          else
+            echo "Latest version installed, skipping version verification."
+          fi
+
+      - name: Install AWS CLI
+        run: pip install awscli
+
+      - name: Install localstack CLI
+        run: pip install localstack
+
+      - name: Start and wait for localstack (Community)
+        timeout-minutes: 10
+        run: |
+          # Check if the localstack-main container is already running
+          if ! docker ps --filter "name=localstack-main" --filter "status=running" -q; then
+            echo "LocalStack container is not running. Starting LocalStack..."
+            docker pull localstack/localstack:latest
+            localstack start -d
+            localstack wait -t 30
+          else
+            echo "LocalStack container is already running. Skipping start."
+          fi
+
+      - name: Set up unique folder
+        run: |
+          export WORK_DIR="cdk-test-$GITHUB_RUN_NUMBER"
+          export STACK_NAME="CdkTest${GITHUB_RUN_NUMBER}Stack"
+          mkdir -p $WORK_DIR
+          echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
+          echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV
+
+      - name: Initialize new CDK app
+        run: |
+          cd $WORK_DIR
+          cdklocal init app --language=python
+
+      - name: Install python libs
+        run: |
+          cd $WORK_DIR
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run bootstrap
+        timeout-minutes: 1
+        run: |
+          cd $WORK_DIR
+          source .venv/bin/activate
+          cdklocal bootstrap
+
+      - name: Deploy
+        timeout-minutes: 1
+        run: |
+          cd $WORK_DIR
+          source .venv/bin/activate
+          cdklocal deploy --require-approval=never
+
+      - name: Clean up
+        if: always()
+        run: rm -rf $WORK_DIR
+
+      - name: Verify successful deployment
+        run: |
+          [ $(aws cloudformation describe-stacks --stack-name $STACK_NAME --endpoint-url http://localhost:4566 | jq '[ .Stacks[] | select(.StackStatus == "CREATE_COMPLETE") ] | length') -eq 1 ] || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY=["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]
+          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
       
       - name: Generate matrix
         id: set-matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   generate-cdk-version-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.env.MATRIX }}
+      matrix: ${{ steps.set-matrix.outputs.MATRIX }}
     steps:
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v2
@@ -35,10 +35,10 @@ jobs:
       - name: Obtain aws-cdk versions
         id: set-matrix
         run: |
-          VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
+          #VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
+          VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq 'sort_by( [ split(".") | .[] | tonumber ] ) | .[-10:]' -c)
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
-          #echo "MATRIX=$MATRIX" >> $GITHUB_ENV
-          echo "MATRIX=$MATRIX" | tee -a $GITHUB_ENV
+          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  
  
   version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ on:
       cdk-version:
         description: Upstream aws-cdk version to use in tests
         required: false
-env:
-  AWS_ACCESS_KEY_ID: test
-  AWS_SECRET_ACCESS_KEY: test
 
 jobs:
   dynamic-cdk-version-testing:
@@ -34,6 +31,8 @@ jobs:
     env:
       AWS_REGION: ${{ matrix.region }}
       AWS_DEFAULT_REGION: ${{ matrix.region }}
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,15 @@ jobs:
         if: ${{ inputs.run-all-latest-cdk-versions == true }}
         run: |
           export VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
+          echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
       
       - name: Obtain default list of aws-cdk versions
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
           export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", "latest"]'
+          echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
+
       
       - name: Generate matrix
         id: set-matrix
@@ -59,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-cdk-version-matrix
     strategy:
-      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix || '{}')}}
+      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix)}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           #echo "MATRIX=$MATRIX" >> $GITHUB_ENV
           echo "MATRIX=$MATRIX" | tee -a $GITHUB_ENV
-          echo $MATRIX
  
  
   version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
         description: Upstream aws-cdk version to use in tests
         required: false
 
+env:
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: test
+
 jobs:
   dynamic-cdk-version-testing:
     runs-on: ubuntu-latest
@@ -23,16 +27,10 @@ jobs:
       matrix:
         node-version: ['22.x']
         python-version: ['3.12']
-        region: ['us-east-1']
 #        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0", ""]') }}
         cdk-version: ${{ fromJson(inputs.cdk-version || '[""]') }}
       fail-fast: false
 
-    env:
-      AWS_REGION: ${{ matrix.region }}
-      AWS_DEFAULT_REGION: ${{ matrix.region }}
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
 
     steps:
       - uses: actions/checkout@v2
@@ -79,6 +77,19 @@ jobs:
       - name: Install localstack CLI
         run: pip install localstack
 
+      - name: Set up unique folder
+        run: |
+          export WORK_DIR="cdk-test$GITHUB_RUN_NUMBER"
+          export STACK_NAME="CdkTest${GITHUB_RUN_NUMBER}Stack"
+          mkdir -p $WORK_DIR
+          echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
+          echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV
+
+      - name: Initialize new CDK app
+        run: |
+          cd $WORK_DIR
+          cdklocal init app --language=python
+
       - name: Start and wait for localstack (Community)
         timeout-minutes: 10
         run: |
@@ -91,19 +102,6 @@ jobs:
           else
             echo "LocalStack container is already running. Skipping start."
           fi
-
-      - name: Set up unique folder
-        run: |
-          export WORK_DIR="cdk-test-$GITHUB_RUN_NUMBER"
-          export STACK_NAME="CdkTest${GITHUB_RUN_NUMBER}Stack"
-          mkdir -p $WORK_DIR
-          echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
-          echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV
-
-      - name: Initialize new CDK app
-        run: |
-          cd $WORK_DIR
-          cdklocal init app --language=python
 
       - name: Install python libs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           source .venv/bin/activate
           if [ "${{ matrix.cdk-version }}" = "1.150.0" ]; then
-            cdk acknowledge 19836
+            cdklocal acknowledge 19836
           fi
           cdklocal bootstrap
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,6 @@ jobs:
         working-directory: repo
         run: |
           npm install
-
-      - name: Install specific aws-cdk version
-        working-directory: repo
-        run:  |
           if [ -n "${{ matrix.cdk-version }}" ]; then
             npm install aws-cdk@${{ matrix.cdk-version }}
           else
@@ -123,10 +119,6 @@ jobs:
           cd $WORK_DIR
           source .venv/bin/activate
           cdklocal deploy --require-approval=never
-
-      - name: Clean up
-        if: always()
-        run: rm -rf $WORK_DIR
 
       - name: Verify successful deployment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
         node-version: ['22.x']
         python-version: ['3.12']
         region: ['us-east-1']
-        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0"]') }}
-      fail-fast: true
+        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0", ""]') }}
+      fail-fast: false
 
     env:
       AWS_REGION: ${{ matrix.region }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,8 @@ jobs:
       matrix:
         node-version: ['22.x']
         python-version: ['3.12']
-#        cdk-version: ${{ fromJson(inputs.cdk-version || '[ "2.166.0", "2.167.0", ""]') }}
         cdk-version: ${{ fromJson(inputs.cdk-version || '[""]') }}
-      fail-fast: false
+      fail-fast: False
 
 
     steps:
@@ -53,10 +52,9 @@ jobs:
         working-directory: repo
         run: |
           npm install
+          npm install aws-cdk
           if [ -n "${{ matrix.cdk-version }}" ]; then
             npm install aws-cdk@${{ matrix.cdk-version }}
-          else
-            npm install aws-cdk
           fi
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
@@ -68,29 +66,20 @@ jobs:
             echo "Latest version installed, skipping version verification."
           fi
 
-#      - name: Install AWS CLI
-#        run: |
-#          pip install awscli
-#          aws configure set aws_access_key_id "AKIAI44QH8DHBEXAMPLE" --profile default
-#          aws configure set aws_secret_access_key "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY" --profile default
-#          aws configure set region "us-east-1" --profile default
-#          aws configure set output "json" --profile default
-
       - name: Install localstack CLI
         run: pip install localstack
 
       - name: Set up unique folder
         run: |
-          export WORK_DIR="cdk-test$GITHUB_RUN_NUMBER"
+          export WORK_DIR="cdk-test-$GITHUB_RUN_NUMBER"
           export STACK_NAME="CdkTest${GITHUB_RUN_NUMBER}Stack"
           mkdir -p $WORK_DIR
           echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
           echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV
 
       - name: Initialize new CDK app
-        run: |
-          cd $WORK_DIR
-          cdklocal init app --language=python
+        working-directory: ${{env.WORK_DIR}}
+        run: cdklocal init app --language=python
 
       - name: Start and wait for localstack (Community)
         timeout-minutes: 10
@@ -106,25 +95,25 @@ jobs:
           fi
 
       - name: Install python libs
+        working-directory: ${{env.WORK_DIR}}
         run: |
-          cd $WORK_DIR
           source .venv/bin/activate
           pip install -r requirements.txt
 
       - name: Run bootstrap
         timeout-minutes: 1
+        working-directory: ${{env.WORK_DIR}}
         run: |
-          cd $WORK_DIR
           source .venv/bin/activate
           cdklocal bootstrap
 
       - name: Deploy
         timeout-minutes: 1
+        working-directory: ${{env.WORK_DIR}}
         run: |
-          cd $WORK_DIR
           source .venv/bin/activate
           cdklocal deploy --require-approval=never
 
       - name: Verify successful deployment
         run: |
-          [ $(aws cloudformation describe-stacks --stack-name $STACK_NAME --endpoint-url http://localhost:4566 | jq '[ .Stacks[] | select(.StackStatus == "CREATE_COMPLETE") ] | length') -eq 1 ] || exit 1
+          [ $(aws cloudformation describe-stacks --stack-name AppTest --endpoint-url http://localhost:4566 | jq '[ .Stacks[] | select(.StackStatus == "CREATE_COMPLETE") ] | length') -eq 1 ] || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   generate-cdk-version-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.env.MATRIX }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v2
@@ -36,8 +36,9 @@ jobs:
         id: set-matrix
         run: |
           VERSIONS_ARRAY=$(npm show aws-cdk time --json --silent| jq 'del(.created, .modified) | keys' -c)
-          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
-          echo $MATRIX
+          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}"
+          echo "::set-output name=matrix::$MATRIX"
+ 
  
   version-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Regression Tests (Python)
+name: Dynamic CDK version testing
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ on:
         description: Upstream aws-cdk version to use in tests
         required: false
 env:
-  AWS_ACCESS_KEY_ID: test
-  AWS_SECRET_ACCESS_KEY: test
+  AWS_ACCESS_KEY_ID: LSIA2KBGMF64YRBX5E0I
+  AWS_SECRET_ACCESS_KEY: ZgF037sgehvieyj4mejFnipU2HvvwnYQlBsguzLK
 
 jobs:
   dynamic-cdk-version-testing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
       python-version:
         required: false
         default: '3.12'
+      run-all-latest-cdk-versions:
+        required: false
+        type: boolean
+        default: false
 
 env:
   AWS_ACCESS_KEY_ID: test
@@ -32,10 +36,19 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ inputs.node-version }}
-      - name: Obtain aws-cdk versions
+      - name: Obtain all aws-cdk latest versions
         id: set-matrix
+        if: ${{ inputs.run-all-latest-cdk-versions == true }}
         run: |
           VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
+          MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+      
+      - name: Obtain default list of aws-cdk versions
+        id: set-matrix
+        if: ${{ inputs.run-all-latest-cdk-versions == false }}
+        run: |
+          VERSIONS_ARRAY=["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           source .venv/bin/activate
+          cdklocal acknowledge 19836
           cdklocal bootstrap
 
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-cdk-version-matrix
     strategy:
-      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix || "{}")}}
+      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix || '{}')}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,9 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           source .venv/bin/activate
+          if [ "${{ matrix.cdk-version }}" = "1.150.0" ]; then
+            cdk acknowledge 19836
+          fi
           cdklocal bootstrap
 
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", "latest"]'
+          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
           echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
 
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           source .venv/bin/activate
-          cdk acknowledge 19836
+          cdklocal acknowledge 19836
           cdklocal bootstrap
 
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         node-version: ['22.x']
         python-version: ['3.12']
-        cdk-version: ${{ fromJson(inputs.cdk-version || '[""]') }}
+        cdk-version: ${{ fromJson(inputs.cdk-version || '["2.166.0","2.167.0", ""]') }}
       fail-fast: False
 
 
@@ -84,15 +84,9 @@ jobs:
       - name: Start and wait for localstack (Community)
         timeout-minutes: 10
         run: |
-          # Check if the localstack-main container is already running
-          if ! docker ps --filter "name=localstack-main" --filter "status=running" -q; then
-            echo "LocalStack container is not running. Starting LocalStack..."
-            docker pull localstack/localstack:latest
-            localstack start -d
-            localstack wait -t 30
-          else
-            echo "LocalStack container is already running. Skipping start."
-          fi
+          docker pull localstack/localstack:latest
+          localstack start -d
+          localstack wait -t 30
 
       - name: Install python libs
         working-directory: ${{env.WORK_DIR}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Obtain aws-cdk versions
         id: set-matrix
         run: |
-          VERSIONS_ARRAY=$(npm show aws-cdk time --json | jq 'del(.created, .modified) | keys' -c)
+          VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
           MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ on:
     inputs:
       node-version:
         required: false
-        default: '22.x'
+        default: "22.x"
       python-version:
         required: false
-        default: '3.12'
+        default: "3.12"
       run-all-latest-cdk-versions:
         required: false
         type: boolean
@@ -42,22 +42,20 @@ jobs:
         run: |
           export VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
           echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
-      
+
       - name: Obtain default list of aws-cdk versions
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY='["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
+          export VERSIONS_ARRAY='["1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
           echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
 
-      
       - name: Generate matrix
         id: set-matrix
         run: |
           export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
- 
- 
+
   version-testing:
     runs-on: ubuntu-latest
     needs: generate-cdk-version-matrix
@@ -77,7 +75,7 @@ jobs:
       - name: Setup Python ${{ inputs.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: '${{ inputs.python-version }}'
+          python-version: "${{ inputs.python-version }}"
 
       - name: Install dependencies for aws-cdk-local
         working-directory: repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
       
       - name: Generate matrix
-        id: simple-matrix
+        id: set-matrix
         run: |
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,14 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: '0 5 * * *'  # once daily at 5AM
   workflow_dispatch:
     inputs:
-      cdk-version:
-        description: Upstream aws-cdk version to use in tests
+      node-version:
         required: false
+        default: '22.x'
+      python-version:
+        required: false
+        default: '3.12'
 
 env:
   AWS_ACCESS_KEY_ID: test
@@ -22,31 +23,41 @@ env:
   AWS_DEFAULT_REGION: us-east-1
 
 jobs:
-  dynamic-cdk-version-testing:
+  generate-cdk-version-matrix:
     runs-on: ubuntu-latest
-
+    outputs:
+      matrix: ${{ steps.set-matrix.env.MATRIX }}
+    steps:
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Obtain aws-cdk versions
+        id: set-matrix
+        run: |
+          VERSIONS_ARRAY=$(npm show aws-cdk time --json --silent| jq 'del(.created, .modified) | keys' -c)
+          echo "MATRIX={\"cdk-version\":$( echo "$VERSIONS_ARRAY" )}" >> $GITHUB_ENV
+ 
+  version-testing:
+    runs-on: ubuntu-latest
+    needs: generate-cdk-version-matrix
     strategy:
-      matrix:
-        node-version: ['22.x']
-        python-version: ['3.12']
-        cdk-version: ${{ fromJson(inputs.cdk-version || '["2.166.0","2.167.0", ""]') }}
-      fail-fast: False
-
+      matrix: ${{fromJson(needs.generate-cdk-version-matrix.outputs.matrix)}}
 
     steps:
       - uses: actions/checkout@v2
         with:
           path: repo
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ inputs.node-version }}
 
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python ${{ inputs.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: '${{ matrix.python-version }}'
+          python-version: '${{ inputs.python-version }}'
 
       - name: Install dependencies for aws-cdk-local
         working-directory: repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,19 +40,18 @@ jobs:
         id: heavy-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == true }}
         run: |
-          VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
-          export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+          export VERSIONS_ARRAY=$(npm view aws-cdk versions --json | jq -c '.[-256:]' )
       
       - name: Obtain default list of aws-cdk versions
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          VERSIONS_ARRAY=["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]
-          export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
+          export VERSIONS_ARRAY=["1.10.0", "1.38.0", "1.95.1", "1.150.0", "2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]
       
       - name: Generate matrix
         id: set-matrix
         run: |
+          export MATRIX="{\"cdk-version\":$VERSIONS_ARRAY}"
           echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
  
  


### PR DESCRIPTION
## Motivation
This PR adds a GitHub workflow which main objective is to test the our aws-cdk-local tool agains multiple aws-cdk versions by simply creating a new python project and deploying it in LS.

## Explanation
The workflows consists in 2 jobs:
- `generate-cdk-versions-matrix` which objective is to pull the list of versions available of `aws-cdk` and generate a strategy matrix. By default it just gives a list of 11 versions (including latest) manually selected.
- `version-testing` grabs the matrix and per each version, installs the CDK lib version, creates a project and tries to deploy it to LS.

## Notes 
The matrix is limited to 256 items due to GH limits. 

