### PR TITLE
Fix compatibility with cdk<2.167.0

### DIFF
--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -161,8 +161,11 @@ const patchProviderCredentials = (provider) => {
     const result = await origConstr(options);
     result.sdkOptions = result.sdkOptions || {}; // legacy
     await setSdkOptions(result.sdkOptions); // legacy
-    result.requestHandler.endpoint = localEndpoint;
-    result.requestHandler.forcePathStyle = true;
+    // >= 2.167.0
+    if (result.requestHandler) {
+      result.requestHandler.endpoint = localEndpoint;
+      result.requestHandler.forcePathStyle = true;
+    }
     return result;
   };
 
@@ -372,7 +375,8 @@ const patchSdkProvider = (provider, SDK) => {
       provider.SdkProvider.prototype[methodName] = async function methFunc(...args) {
         const localEndpoint = await getLocalEndpoint();
 
-        if (!sdkOverwritten) {
+        // patch for >= 2.167.0
+        if (!sdkOverwritten && this.requestHandler) {
           // the goal is to support `SdkProvider.withAssumedRole`
           // since it instantiates a different client (i.e. not from the SDK class)
           this.requestHandler.endpoint = localEndpoint;


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/localstack/aws-cdk-local/pull/96 which fixed compatibility with `aws-cdk >=2.167.0` but introduced assumptions that were not holding against older AWS CDK versions (e.g. `2.166.0`).

Symptom: When running `cdklocal` it now failed with: `Cannot set properties of undefined (setting 'endpoint')`

These kind of issues will be prevented in the future by testing against multiple older AWS CDK versions (see https://github.com/localstack/aws-cdk-local/pull/98). In fact this issue here was already discovered via those [initial tests](https://github.com/localstack/aws-cdk-local/actions/runs/12143965374/job/33862127491?pr=98)!

I'll wait until we have the CI from #98 ready and then potentially have fixed more regressions for even older versions, before publishing an updated version.