### PR TITLE
Fix bucket location patch for the TemplateURL when deploying a stack

### DIFF
--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -18,7 +18,6 @@ const EDGE_PORT = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
 const DEFAULT_HOSTNAME = "localhost";
 const LAMBDA_MOUNT_CODE = isEnvTrue("LAMBDA_MOUNT_CODE");
 const PROTOCOL = isEnvTrue("USE_SSL") ? "https" : "http";
-const DEBUG_ON = process.env.DEBUG === "1";
 
 
 //----------------
@@ -28,6 +27,14 @@ const DEBUG_ON = process.env.DEBUG === "1";
 const getLocalEndpoint = async () => process.env.AWS_ENDPOINT_URL || `${PROTOCOL}://${await getLocalHost()}`;
 
 var resolvedHostname = undefined;
+
+const runAsyncFunctionAsSync = (asyncFn) => {
+  return (...args) => {
+    asyncFn(...args).catch((e) => {
+      console.error(e);
+    });
+  };
+};
 
 const getLocalHost = async () => {
   if (resolvedHostname) {
@@ -207,10 +214,6 @@ const patchCurrentAccount = (SDK) => {
 const patchToolkitInfo = (ToolkitInfo) => {
   const setBucketUrl = function setBucketUrl(object, bucket, domain) {
     const newBucketUrl = `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;
-    if (DEBUG_ON) {
-      console.debug("Old bucketUrl:", object.bucketUrl);
-      console.debug("New bucketUrl:", newBucketUrl);
-    }
     Object.defineProperty(object, "bucketUrl", {
       get() {
         return newBucketUrl;
@@ -221,7 +224,7 @@ const patchToolkitInfo = (ToolkitInfo) => {
   // Pre-fetch the necessary values for the bucket URL
   const prefetchBucketUrl = async (object) => {
     // Has been observed that the object is not always an instance of ToolkitInfo
-    if (object != {}) {
+    if (object && Object.prototype.hasOwnProperty.call(object, "bucketName") && Object.prototype.hasOwnProperty.call(object, "bucketUrl")) {
       try {
         const bucket = object.bucketName;
         const domain = object.bucketUrl.replace("https://", "") || await getLocalHost();
@@ -241,7 +244,7 @@ const patchToolkitInfo = (ToolkitInfo) => {
   };
 
   // for compatibility with with older versions of CDK
-  prefetchBucketUrl(ToolkitInfo.prototype);
+  runAsyncFunctionAsSync(prefetchBucketUrl(ToolkitInfo.prototype));
 
   const cdkLookupFn = ToolkitInfo.lookup;
   ToolkitInfo.lookup = async (...args) => {
@@ -253,7 +256,7 @@ const patchToolkitInfo = (ToolkitInfo) => {
   const fromStackFn = ToolkitInfo.fromStack;
   ToolkitInfo.fromStack = (...args) => {
     const toolkitInfoObject = fromStackFn(...args);
-    prefetchBucketUrl(toolkitInfoObject);
+    runAsyncFunctionAsSync(prefetchBucketUrl(toolkitInfoObject));
     return toolkitInfoObject;
   };
 };

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -126,6 +126,7 @@ const getTemplateBody = async (params) => {
     return params.TemplateBody;
   }
   const templateURL = await Promise.resolve(params.TemplateURL);
+  console.info(`Fetching template from URL: ${templateURL}`);
   return await fetchURLAsync(templateURL);
 };
 
@@ -209,30 +210,51 @@ const patchToolkitInfo = (ToolkitInfo) => {
     BUCKET_NAME_OUTPUT, BUCKET_DOMAIN_NAME_OUTPUT
   } = require("aws-cdk/lib/api/bootstrap/bootstrap-props");
 
-  const setBucketUrl = function setBucketUrl(object) {
+  const setBucketUrl = function setBucketUrl(object, bucket, domain) {
+    console.debug("New bucketUrl", `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`);
     Object.defineProperty(object, "bucketUrl", {
-      async get() {
-        const bucket = this.requireOutput(BUCKET_NAME_OUTPUT);
-        const domain = this.requireOutput(BUCKET_DOMAIN_NAME_OUTPUT) || await getLocalHost();
+      get() {
         return `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;
       }
     });
   };
 
+  // Pre-fetch the necessary values for the bucket URL
+  const prefetchBucketUrl = async (object) => {
+    // Has been observed that the object is not always an instance of ToolkitInfo
+    if (object != {}) {
+      try {
+        const bucket = object.bucketName;
+        const domain = object.bucketUrl.replace("https://", "") || await getLocalHost();
+        // When object is ExistingToolkitInfo & the bucketName/bucketUrl attributes are non-null
+        setBucketUrl(object, bucket, domain);
+      } catch (e) {
+        // ToolkitInfo: bucketName/bucketUrl attributes don't exist or if implemented, they throw exceptions
+        // so the exceptions have to be ignored.
+        //
+        // The following is an example of how the bucketName/bucketUrl attributes are implemented in the BootstrapStackNotFoundInfos class:
+        // I.e.: https://github.com/aws/aws-cdk/blob/87e21d625af86873716734dd5568940d41096c45/packages/aws-cdk/lib/api/toolkit-info.ts#L190-L196
+        // 
+        // The following is an example of how the bucketName/bucketUrl attributes are implemented in the ExistingToolkitInfo class:
+        // I.e.: https://github.com/aws/aws-cdk/blob/87e21d625af86873716734dd5568940d41096c45/packages/aws-cdk/lib/api/toolkit-info.ts#L124-L130
+      }
+    }
+  };
+
   // for compatibility with with older versions of CDK
-  setBucketUrl(ToolkitInfo.prototype);
+  prefetchBucketUrl(ToolkitInfo.prototype);
 
   const cdkLookupFn = ToolkitInfo.lookup;
   ToolkitInfo.lookup = async (...args) => {
     const toolkitInfoObject = await cdkLookupFn(...args);
-    setBucketUrl(toolkitInfoObject);
+    await prefetchBucketUrl(toolkitInfoObject);
     return toolkitInfoObject;
   };
-
+  
   const fromStackFn = ToolkitInfo.fromStack;
   ToolkitInfo.fromStack = (...args) => {
     const toolkitInfoObject = fromStackFn(...args);
-    setBucketUrl(toolkitInfoObject);
+    prefetchBucketUrl(toolkitInfoObject);
     return toolkitInfoObject;
   };
 };

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -121,13 +121,11 @@ const fetchURLAsync = (url) => new Promise((resolve, reject) => {
   req.end();
 });
 
-const getTemplateBody = async (params) => {
+const getTemplateBody = (params) => {
   if (params.TemplateBody) {
     return params.TemplateBody;
   }
-  const templateURL = await Promise.resolve(params.TemplateURL);
-  console.info(`Fetching template from URL: ${templateURL}`);
-  return await fetchURLAsync(templateURL);
+  return fetchURLAsync(params.TemplateURL);
 };
 
 // small import util function

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -18,6 +18,7 @@ const EDGE_PORT = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
 const DEFAULT_HOSTNAME = "localhost";
 const LAMBDA_MOUNT_CODE = isEnvTrue("LAMBDA_MOUNT_CODE");
 const PROTOCOL = isEnvTrue("USE_SSL") ? "https" : "http";
+const DEBUG_ON = process.env.DEBUG === "1";
 
 
 //----------------
@@ -209,7 +210,10 @@ const patchToolkitInfo = (ToolkitInfo) => {
   } = require("aws-cdk/lib/api/bootstrap/bootstrap-props");
 
   const setBucketUrl = function setBucketUrl(object, bucket, domain) {
-    console.debug("New bucketUrl", `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`);
+    if (DEBUG_ON) {
+      console.debug("Old bucketUrl:", object.bucketUrl);
+      console.debug("New bucketUrl:", `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`);
+    }
     Object.defineProperty(object, "bucketUrl", {
       get() {
         return `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -205,10 +205,6 @@ const patchCurrentAccount = (SDK) => {
 };
 
 const patchToolkitInfo = (ToolkitInfo) => {
-  const {
-    BUCKET_NAME_OUTPUT, BUCKET_DOMAIN_NAME_OUTPUT
-  } = require("aws-cdk/lib/api/bootstrap/bootstrap-props");
-
   const setBucketUrl = function setBucketUrl(object, bucket, domain) {
     if (DEBUG_ON) {
       console.debug("Old bucketUrl:", object.bucketUrl);

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -121,11 +121,11 @@ const fetchURLAsync = (url) => new Promise((resolve, reject) => {
   req.end();
 });
 
-const getTemplateBody = (params) => {
+const getTemplateBody = async (params) => {
   if (params.TemplateBody) {
     return params.TemplateBody;
   }
-  return fetchURLAsync(params.TemplateURL);
+  return await fetchURLAsync(params.TemplateURL);
 };
 
 // small import util function

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -125,7 +125,8 @@ const getTemplateBody = async (params) => {
   if (params.TemplateBody) {
     return params.TemplateBody;
   }
-  return await fetchURLAsync(params.TemplateURL);
+  const templateURL = await Promise.resolve(params.TemplateURL);
+  return await fetchURLAsync(templateURL);
 };
 
 // small import util function

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -206,13 +206,14 @@ const patchCurrentAccount = (SDK) => {
 
 const patchToolkitInfo = (ToolkitInfo) => {
   const setBucketUrl = function setBucketUrl(object, bucket, domain) {
+    const newBucketUrl = `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;
     if (DEBUG_ON) {
       console.debug("Old bucketUrl:", object.bucketUrl);
-      console.debug("New bucketUrl:", `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`);
+      console.debug("New bucketUrl:", newBucketUrl);
     }
     Object.defineProperty(object, "bucketUrl", {
       get() {
-        return `https://${domain.replace(`${bucket}.`, "")}:${EDGE_PORT}/${bucket}`;
+        return newBucketUrl;
       }
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.18.1",
+      "version": "2.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.19.0",
+  "version": "2.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.19.0",
+      "version": "2.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"
@@ -191,9 +191,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1055,9 +1055,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -1589,9 +1589,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,9 +191,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1055,9 +1055,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -1589,9 +1589,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrappy": {


### PR DESCRIPTION
#### Description

When S3 is used as a place of store for the CF artifacts, the resolving of the actual `bucketUrl` within our patch would lead to the presence of a stringified version of a promise, i.e.: `'[object Promise]/cdk/digitalu-local-services/dbdbe3071265081abdd49572f43ec8168bc6fb4250c190631f9e84f51a5ccb4c.yml'`. Because of this, what was supposed to be the first prefix within the bucket is now considered to be the bucket. Chaos ensues, and the stack fails to deploy because the S3 bucket _"does not exist"_.

 So instead of using promises for our patched version of `bucketUrl` attribute, we instead determine the bucket name/URL outside of the function associated with it.

While doing this, it was also noticed how the `ToolkitInfo` object isn't always a `ToolkitInfo` object anymore:
1. Can be `{}` (empty key-value pair object).
2. Can be `BootstrapStackNotFoundInfo` in which case calling `bucketUrl` or `bucketName` would throw an exception.
3. Can be `ExistingToolkitInfo`, which is the ideal case, and also the case when we should patch `bucketUrl` attribute.

These classes can be observed here: https://github.com/aws/aws-cdk/blob/87e21d625af86873716734dd5568940d41096c45/packages/aws-cdk/lib/api/toolkit-info.ts