### PR TITLE
Fix: support aws-cdk>=2.177.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         id: simple-matrix
         if: ${{ inputs.run-all-latest-cdk-versions == false }}
         run: |
-          export VERSIONS_ARRAY='["2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", ""]'
+          export VERSIONS_ARRAY='["2.30.0", "2.50.0", "2.75.0", "2.120.0", "2.166.0", "2.167.0", "2.177.0", ""]'
           echo "VERSIONS_ARRAY=$VERSIONS_ARRAY" >> $GITHUB_ENV
 
       - name: Generate matrix

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 2.19.2: Fix SDK compatibility with aws-cdk versions >= 2.177.0
 * 2.19.1: Fix SDK compatibility with older CDK versions; Fix patched bucket location in TemplateURL
 * 2.19.0: Add support for aws-cdk versions >= `2.167.0`
 * 2.18.1: Throw better exception if `aws-cdk` not found

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ export NODE_PATH=$NODE_PATH:/opt/homebrew/Cellar/aws-cdk/<CDK_VERSION>/libexec
 The following environment variables can be configured:
 
 * `AWS_ENDPOINT_URL`: The endpoint URL to connect to (combination of `USE_SSL`/`LOCALSTACK_HOSTNAME`/`EDGE_PORT` below)
+* `AWS_ENDPOINT_URL_S3`: The endpoint URL to connect to (combination of `USE_SSL`/`LOCALSTACK_HOSTNAME`/`EDGE_PORT` below) for S3 requests
 * `EDGE_PORT` (deprecated): Port under which LocalStack edge service is accessible (default: `4566`)
 * `LOCALSTACK_HOSTNAME` (deprecated): Target host under which LocalStack edge service is accessible (default: `localhost`)
 * `USE_SSL` (deprecated): Whether to use SSL to connect to the LocalStack endpoint, i.e., connect via HTTPS.

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -478,17 +478,17 @@ const patchPost_2_14 = () => {
     require("aws-cdk/lib/legacy-exports");
   } catch (e) {
     switch (e.code) {
-      case "MODULE_NOT_FOUND":
-        // pre 2.177
-        applyPatches(lib, lib, lib.SDK, lib.ToolkitInfo, false);
-        break;
-      case "ERR_PACKAGE_PATH_NOT_EXPORTED":
-        // post 2.177
-        configureEnvironment();
-        break;
-      default:
-        // a different error
-        throw e
+    case "MODULE_NOT_FOUND":
+      // pre 2.177
+      applyPatches(lib, lib, lib.SDK, lib.ToolkitInfo, false);
+      break;
+    case "ERR_PACKAGE_PATH_NOT_EXPORTED":
+      // post 2.177
+      configureEnvironment();
+      break;
+    default:
+      // a different error
+      throw e
     }
   }
 };

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -252,7 +252,7 @@ const patchToolkitInfo = (ToolkitInfo) => {
     await prefetchBucketUrl(toolkitInfoObject);
     return toolkitInfoObject;
   };
-  
+
   const fromStackFn = ToolkitInfo.fromStack;
   ToolkitInfo.fromStack = (...args) => {
     const toolkitInfoObject = fromStackFn(...args);
@@ -451,6 +451,13 @@ const patchPre_2_14 = () => {
   applyPatches(provider, CdkToolkit, SDK, ToolkitInfo);
 };
 
+const configureEnvironment = () => {
+  // This _must_ use localhost.localstack.cloud as we require valid subdomains of these paths to
+  // resolve. Unfortunately though `curl` seems to support subdomains of localhost, the CDK does not.
+  process.env.AWS_ENDPOINT_URL_S3 = process.env.AWS_ENDPOINT_URL_S3 || `${PROTOCOL}://s3.localhost.localstack.cloud:${EDGE_PORT}`;
+  process.env.AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL || `${PROTOCOL}://localhost.localstack.cloud:${EDGE_PORT}`;
+};
+
 const patchPost_2_14 = () => {
   var lib = null;
   try {
@@ -463,7 +470,27 @@ const patchPost_2_14 = () => {
     }
   }
 
-  applyPatches(lib, lib, lib.SDK, lib.ToolkitInfo, false);
+  // detect if we are using version 2.177.0 or later. This version has reorganised the package
+  // structure so that we cannot import and patch the aws-cdk package as we did for versions
+  // <2.177.0. We use the specific error raised by the node require system to determine if we are
+  // using pre or post 2.177.0.
+  try {
+    require("aws-cdk/lib/legacy-exports");
+  } catch (e) {
+    switch (e.code) {
+      case "MODULE_NOT_FOUND":
+        // pre 2.177
+        applyPatches(lib, lib, lib.SDK, lib.ToolkitInfo, false);
+        break;
+      case "ERR_PACKAGE_PATH_NOT_EXPORTED":
+        // post 2.177
+        configureEnvironment();
+        break;
+      default:
+        // a different error
+        throw e
+    }
+  }
 };
 
 if (isEsbuildBundle()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "2.18.1",
+  "version": "2.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "2.18.1",
+      "version": "2.19.2",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "bin": {
     "cdklocal": "bin/cdklocal"
   },


### PR DESCRIPTION
# Motivation

Addresses https://github.com/localstack/aws-cdk-local/issues/106

The CDK team have [recently made a change](https://github.com/aws/aws-cdk/commit/e5ac918efbb66674176c81171e0d61affddcbeab) to not export some internal types of the `aws-cdk` package. We rely on these types to override the endpoint url to point to LocalStack. This therefore broke our integration with the CDK.

# Changes

* Detect when `aws-cdk>=2.177.0` is installed, and instead use the `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_S3` environment variables to configure the JavaScript SDKs
