### PR TITLE
Print cdklocal version and cdk version if possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 3.0.1: Using the `-v`/`--version` flag prints the cdklocal version and the version of the underlying `aws-cdk` package (if possible)
 * 3.0.0: Sanitise environment of configuration environment variables before deployment
 * 2.19.2: Fix SDK compatibility with aws-cdk versions >= 2.177.0
 * 2.19.1: Fix SDK compatibility with older CDK versions; Fix patched bucket location in TemplateURL

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -9,7 +9,8 @@ const https = require("https");
 const crypto = require("crypto");
 const net = require('net');
 
-const { isEnvTrue, EDGE_PORT, PROTOCOL, configureEnvironment } = require("../src");
+const { isEnvTrue, EDGE_PORT, PROTOCOL, configureEnvironment } = require(path.resolve(__dirname, "..", "src"));
+const pkg = require(path.resolve(__dirname, "..", "package.json"));
 
 // constants and custom config values
 
@@ -21,6 +22,17 @@ const AWS_ENVAR_ALLOWLIST = process.env.AWS_ENVAR_ALLOWLIST || "";
 //----------------
 // UTIL FUNCTIONS
 //----------------
+
+function printVersion() {
+  try {
+    const lib = require("aws-cdk/lib");
+    const cdkVersion = require(path.join(lib.rootDir(), 'package.json')).version.replace(/\+[0-9a-f]+$/, '');
+    console.log(`cdklocal v${pkg.version}`);
+    console.log(`cdk cli version v${cdkVersion}`);
+  } catch (e) {
+    console.log(`cdklocal v${pkg.version}`);
+  }
+}
 
 const getLocalEndpoint = async () => process.env.AWS_ENDPOINT_URL || `${PROTOCOL}://${await getLocalHost()}`;
 
@@ -483,6 +495,12 @@ const patchPost_2_14 = () => {
     }
   }
 };
+
+// handle printing version information
+if (process.argv[2] === "--version" || process.argv[2] === "-v") {
+  printVersion();
+  process.exit(0);
+}
 
 if (isEsbuildBundle()) {
   // load for CDK version 2.14.0 and above

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "src/index.js",
   "bin": {
     "cdklocal": "bin/cdklocal"


### PR DESCRIPTION
# Motivation

A user reported an issue with cdklocal but when the printed their `cdklocal --version` output it printed the underling `aws-cdk` version (i.e. the CLI version).

# Changes

- Implement printing cdklocal version as well as cdk version
- Update changelog
- Bump version
