### PR TITLE
fix: patch SdkProvider._makeSdk for CDK >= 2.177.0 to support path-style S3 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ $ awslocal sns list-topics
 
 ## Change Log
 
+* 3.0.4: Fix asset publishing failures for CDK >= 2.177.0 against remote LocalStack endpoints (e.g. `*.sandbox.localstack.cloud`)
 * 3.0.3: Add missing `semver` dependency
 * 3.0.2: Add support for `aws-cdk` versions after 2026-03-01 (see https://github.com/aws/aws-cdk-cli/issues/310)
 * 3.0.1: Using the `-v`/`--version` flag prints the cdklocal version and the version of the underlying `aws-cdk` package (if possible)

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -115,6 +115,16 @@ const useLocal = () => {
   return true;
 };
 
+// require("aws-cdk/lib") resolves to legacy-exports.js which re-exports SdkProvider as a thin
+// wrapper with only static methods. The real SdkProvider (with _makeSdk and other instance
+// methods) lives in index.js. Load it directly by resolving the package root and bypassing
+// the exports field.
+const loadRealSdkProvider = () => {
+  const cdkRoot = path.dirname(require.resolve("aws-cdk/package.json"));
+  const indexLib = require(path.join(cdkRoot, "lib", "index.js"));
+  return indexLib.SdkProvider;
+};
+
 const shouldForcePathStyle = () => {
   if (isEnvTrue(process.env.AWS_S3_FORCE_PATH_STYLE)) {
     return true;
@@ -497,21 +507,16 @@ const patchPost_2_14 = () => {
     case "ERR_PACKAGE_PATH_NOT_EXPORTED":
       // post 2.177
       configureEnvironment(process.env, AWS_ENVAR_ALLOWLIST);
-      // require("aws-cdk/lib") resolves to legacy-exports.js which re-exports SdkProvider
-      // as a thin wrapper with only static methods. The real SdkProvider (with _makeSdk
-      // and other instance methods) lives in index.js. Load index.js directly by resolving
-      // the package root and bypassing the exports field, then patch _makeSdk to inject
-      // forcePathStyle:true into every SDK instance's config so S3Client uses path-style URLs.
-      // Required for remote LocalStack endpoints (e.g. *.sandbox.localstack.cloud) where
-      // the wildcard TLS cert only covers one subdomain level.
       try {
-        const cdkRoot = path.dirname(require.resolve("aws-cdk/package.json"));
-        const indexLib = require(path.join(cdkRoot, "lib", "index.js"));
-        const RealSdkProvider = indexLib.SdkProvider;
+        const RealSdkProvider = loadRealSdkProvider();
         if (RealSdkProvider && typeof RealSdkProvider.prototype._makeSdk === "function") {
           const origMakeSdk = RealSdkProvider.prototype._makeSdk;
           RealSdkProvider.prototype._makeSdk = function patchedMakeSdk(...args) {
             const sdk = origMakeSdk.apply(this, args);
+            // S3 assets are uploaded using path-style URLs (e.g. https://<host>/<bucket>/...)
+            // rather than virtual-hosted-style (e.g. https://<bucket>.<host>/...).
+            // This is required for sandbox endpoints whose wildcard TLS cert only covers
+            // one subdomain level, and can also be opted into via AWS_S3_FORCE_PATH_STYLE.
             if (sdk && sdk.config && shouldForcePathStyle()) {
               sdk.config.forcePathStyle = true;
             }

--- a/bin/cdklocal
+++ b/bin/cdklocal
@@ -115,6 +115,18 @@ const useLocal = () => {
   return true;
 };
 
+const shouldForcePathStyle = () => {
+  if (isEnvTrue(process.env.AWS_S3_FORCE_PATH_STYLE)) {
+    return true;
+  }
+  const endpointUrl = process.env.AWS_ENDPOINT_URL || "";
+  try {
+    return new URL(endpointUrl).hostname.includes(".sandbox.");
+  } catch {
+    return false;
+  }
+};
+
 const md5 = s => crypto.createHash("md5").update(s).digest("hex");
 
 const getMethods = (obj) => {
@@ -485,6 +497,30 @@ const patchPost_2_14 = () => {
     case "ERR_PACKAGE_PATH_NOT_EXPORTED":
       // post 2.177
       configureEnvironment(process.env, AWS_ENVAR_ALLOWLIST);
+      // require("aws-cdk/lib") resolves to legacy-exports.js which re-exports SdkProvider
+      // as a thin wrapper with only static methods. The real SdkProvider (with _makeSdk
+      // and other instance methods) lives in index.js. Load index.js directly by resolving
+      // the package root and bypassing the exports field, then patch _makeSdk to inject
+      // forcePathStyle:true into every SDK instance's config so S3Client uses path-style URLs.
+      // Required for remote LocalStack endpoints (e.g. *.sandbox.localstack.cloud) where
+      // the wildcard TLS cert only covers one subdomain level.
+      try {
+        const cdkRoot = path.dirname(require.resolve("aws-cdk/package.json"));
+        const indexLib = require(path.join(cdkRoot, "lib", "index.js"));
+        const RealSdkProvider = indexLib.SdkProvider;
+        if (RealSdkProvider && typeof RealSdkProvider.prototype._makeSdk === "function") {
+          const origMakeSdk = RealSdkProvider.prototype._makeSdk;
+          RealSdkProvider.prototype._makeSdk = function patchedMakeSdk(...args) {
+            const sdk = origMakeSdk.apply(this, args);
+            if (sdk && sdk.config && shouldForcePathStyle()) {
+              sdk.config.forcePathStyle = true;
+            }
+            return sdk;
+          };
+        }
+      } catch (patchErr) {
+        // swallow - patch is best-effort for endpoints that don't need path-style
+      }
       break;
     default:
       // a different error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-cdk-local",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-cdk-local",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "diff": "^5.0.0",
@@ -1087,7 +1087,7 @@
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
@@ -1408,7 +1408,7 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
@@ -3189,7 +3189,7 @@
       }
     },
     "node_modules/kleur": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
@@ -5013,7 +5013,7 @@
       "dev": true
     },
     "@types/istanbul-lib-report": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
@@ -5250,7 +5250,7 @@
       }
     },
     "braces": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
@@ -6486,7 +6486,7 @@
       "dev": true
     },
     "kleur": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-cdk-local",
   "description": "CDK Toolkit for use with LocalStack",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "src/index.js",
   "bin": {
     "cdklocal": "bin/cdklocal"


### PR DESCRIPTION
## Problem

When using `cdklocal deploy` with CDK >= 2.177.0 against a remote LocalStack endpoint (e.g. `*.sandbox.localstack.cloud`), asset publishing fails with TLS errors:

```
QuizAppStack: fail: write EPROTO C0988EF501000000:error:0A000438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:ssl/record/rec_layer_s3.c:918:SSL alert number 80

Failed to publish asset GetQuizFunctionLambdaFunction/Code (current_account-current_region-3be8a451)
```

The root cause is that CDK 2.177.0 reorganised its package structure — `aws-cdk/lib` now resolves to `legacy-exports.js`, a thin static wrapper that no longer exposes the real `SdkProvider` instance methods (e.g. `_makeSdk`). As a result, the existing patching mechanism in `cdklocal` no longer takes effect, and S3 clients are created without `forcePathStyle: true`.

Without path-style URLs, the AWS SDK constructs S3 requests using virtual-hosted-style URLs (e.g. `https://<bucket>.abc.sandbox.localstack.cloud/...`). The wildcard TLS certificate for sandbox endpoints only covers one subdomain level, so these requests fail the TLS handshake with an internal alert.

## Solution

Load the real `SdkProvider` by resolving the CDK package root and requiring `index.js` directly (bypassing the `exports` field), then patch `_makeSdk` to inject `forcePathStyle: true` into every SDK instance's config.

The patch is applied conditionally — only when one of the following is true:

- **`AWS_S3_FORCE_PATH_STYLE` is set** — explicit opt-in via env var
- **`AWS_ENDPOINT_URL` hostname contains `.sandbox.`** — automatic detection for remote LocalStack sandbox endpoints
